### PR TITLE
Enable trunk superlinter (clang-tidy & more)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,7 @@
+*out
+*logs
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/config/.clang-format
+++ b/.trunk/config/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Mozilla

--- a/.trunk/config/.clang-tidy
+++ b/.trunk/config/.clang-tidy
@@ -1,0 +1,39 @@
+Checks: >-
+  bugprone-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -bugprone-lambda-function-name,
+  -bugprone-reserved-identifier,
+  -cppcoreguidelines-avoid-goto,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-type-vararg,
+  -google-readability-braces-around-statements,
+  -google-readability-function-size,
+  -misc-no-recursion,
+  -modernize-return-braced-init-list,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -performance-unnecessary-value-param,
+  -readability-magic-numbers,
+
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 100
+  - key: readability-function-cognitive-complexity.IgnoreMacros
+    value: true
+  # Set naming conventions for your style below (there are dozens of naming settings possible):
+  # See https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase

--- a/.trunk/config/.markdownlint.yaml
+++ b/.trunk/config/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,24 @@
+version: 0.1
+cli:
+  version: 1.1.0
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.6
+      uri: https://github.com/trunk-io/plugins
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
+lint:
+  enabled:
+    - actionlint@1.6.22
+    - clang-format@14.0.0
+    - clang-tidy@14.0.0
+    - git-diff-check
+    - gitleaks@8.11.2
+    - markdownlint@0.32.2
+    - prettier@2.7.1
+  ignore:
+    - linters: [ALL]
+      paths: [ThirdParty]


### PR DESCRIPTION
I know this project is kind of old, but figured I'd level up the automated code-checking situation here. This PR turns on the trunk superlinter, that runs clang-tidy, which is otherwise quite difficult to run in a useful way. Overall there were 7 linters, autoformatters, and security tools applicable to the tech in plutil that trunk can run.

If the maintainers are interested, the next step (which I can do) would be enabling running `trunk check` as a CI job, which can be setup to grandfather in preexisting issues, as well as annotate PRs with the issues it finds. Developers can use the [trunk vscode extension](https://marketplace.visualstudio.com/items?itemName=trunk.io) or [trunk cli
](https://docs.trunk.io/docs) to see issues locally before pushing a PR as well.

<hr>

![2022-11-18 14 55 56](https://user-images.githubusercontent.com/3904462/202823123-fb1c1c18-f9c5-40a0-9b17-3bb1f327d612.gif)